### PR TITLE
Bugfix for copy number tools

### DIFF
--- a/src/main/modules/common/R-2.15/acgh-cluster.R
+++ b/src/main/modules/common/R-2.15/acgh-cluster.R
@@ -6,13 +6,13 @@
 # PARAMETER column: column TYPE METACOLUMN_SEL DEFAULT group (Phenodata column to include in the output plot.)
 
 # Ilari Scheinin <firstname.lastname@gmail.com>
-# 2012-10-12
+# 2013-04-04
 
 library(WECCA)
 
 file <- 'regions.tsv'
 dat <- read.table(file, header=TRUE, sep='\t', quote='', row.names=1, as.is=TRUE, check.names=FALSE)
-phenodata <- read.table("phenodata.tsv", header=TRUE, sep="\t", as.is=TRUE)
+phenodata <- read.table("phenodata.tsv", header=TRUE, sep="\t", as.is=TRUE, check.names=FALSE)
 
 dat$chromosome[dat$chromosome=='X'] <- '23'
 dat$chromosome[dat$chromosome=='Y'] <- '24'

--- a/src/main/modules/common/R-2.15/acgh-group-test.R
+++ b/src/main/modules/common/R-2.15/acgh-group-test.R
@@ -9,11 +9,11 @@
 # PARAMETER test.aberrations: test.aberrations TYPE [1: gains, -1: losses, 0: both] DEFAULT 0 (Whether to test only for gains or losses, or both.) 
 
 # Ilari Scheinin <firstname.lastname@gmail.com>
-# 2013-03-06
+# 2013-04-04
 
 file <- 'regions.tsv'
 dat <- read.table(file, header=TRUE, sep='\t', quote='', row.names=1, as.is=TRUE, check.names=FALSE)
-phenodata <- read.table('phenodata.tsv', header=TRUE, sep='\t')
+phenodata <- read.table('phenodata.tsv', header=TRUE, sep='\t', check.names=FALSE)
 
 groupnames <- unique(phenodata[,column])
 groupnames <- groupnames[!is.na(groupnames)]

--- a/src/main/modules/common/R-2.15/acgh-match-probes.R
+++ b/src/main/modules/common/R-2.15/acgh-match-probes.R
@@ -12,7 +12,7 @@
 
 # match-cn-and-expression-probes.R
 # Ilari Scheinin <firstname.lastname@gmail.com>
-# 2013-03-20
+# 2013-04-04
 
 source(file.path(chipster.common.path, 'CGHcallPlus.R'))
 library(intCNGEan)
@@ -21,8 +21,8 @@ file1 <- 'aberrations.tsv'
 file2 <- 'normalized.tsv'
 dat1 <- read.table(file1, header=TRUE, sep='\t', quote='', row.names=1, as.is=TRUE, check.names=FALSE)
 dat2 <- read.table(file2, header=TRUE, sep='\t', quote='', row.names=1, as.is=TRUE, check.names=FALSE)
-phenodata1 <- read.table("phenodata_cgh.tsv", header=T, sep='\t', quote='', as.is=TRUE)
-phenodata2 <- read.table("phenodata_exp.tsv", header=T, sep='\t', quote='', as.is=TRUE)
+phenodata1 <- read.table("phenodata_cgh.tsv", header=T, sep='\t', quote='', as.is=TRUE, check.names=FALSE)
+phenodata2 <- read.table("phenodata_exp.tsv", header=T, sep='\t', quote='', as.is=TRUE, check.names=FALSE)
 
 # determine which dataset is cgh
 if (length(grep("^probnorm\\.", names(dat1)))!=0) {

--- a/src/main/modules/common/R-2.15/acgh-plot-frequencies.R
+++ b/src/main/modules/common/R-2.15/acgh-plot-frequencies.R
@@ -6,14 +6,14 @@
 # PARAMETER chromosomes: chromosomes TYPE STRING DEFAULT 0 (The numbers of the chromosomes to be plotted, separated by commas. 0 means all chromosomes. Ranges are also supported (e.g. 1,3,7-10\).)
 
 # Ilari Scheinin <firstname.lastname@gmail.com>
-# 2013-03-06
+# 2013-04-04
 
 source(file.path(chipster.common.path, 'CGHcallPlus.R'))
 
 # read input files
 file <- 'aberrations.tsv'
 dat <- read.table(file, header=TRUE, sep='\t', quote='', row.names=1, as.is=TRUE, check.names=FALSE)
-phenodata <- read.table("phenodata.tsv", header=TRUE, sep="\t", as.is=TRUE)
+phenodata <- read.table("phenodata.tsv", header=TRUE, sep="\t", as.is=TRUE, check.names=FALSE)
 
 pos <- c('chromosome','start','end')
 if (length(setdiff(pos, colnames(dat)))!=0)

--- a/src/main/modules/common/R-2.15/acgh-plot-survival.R
+++ b/src/main/modules/common/R-2.15/acgh-plot-survival.R
@@ -6,13 +6,13 @@
 # PARAMETER status: status TYPE METACOLUMN_SEL DEFAULT status (Phenodata column with patient status: alive=0, dead=1)
 
 # Ilari Scheinin <firstname.lastname@gmail.com>
-# 2012-10-12
+# 2013-04-04
 
 library(survival)
 
 file <- 'survival-test.tsv'
 dat <- read.table(file, header=TRUE, sep='\t', quote='', row.names=1, as.is=TRUE, check.names=FALSE)
-phenodata <- read.table('phenodata.tsv', header=TRUE, sep='\t')
+phenodata <- read.table('phenodata.tsv', header=TRUE, sep='\t', check.names=FALSE)
 
 s <- Surv(phenodata[,survival], phenodata[,status])
 reg <- as.matrix(dat[, grep('^flag\\.', colnames(dat))])

--- a/src/main/modules/common/R-2.15/acgh-survival-test.R
+++ b/src/main/modules/common/R-2.15/acgh-survival-test.R
@@ -8,11 +8,11 @@
 # PARAMETER test.aberrations: test.aberrations TYPE [1: gains, -1: losses, 0: both] DEFAULT 0 (Whether to test only for gains or losses, or both.) 
 
 # Ilari Scheinin <firstname.lastname@gmail.com>
-# 2012-10-12
+# 2013-04-04
 
 file <- 'regions.tsv'
 dat <- read.table(file, header=TRUE, sep='\t', quote='', row.names=1, as.is=TRUE, check.names=FALSE)
-phenodata <- read.table('phenodata.tsv', header=TRUE, sep='\t')
+phenodata <- read.table('phenodata.tsv', header=TRUE, sep='\t', check.names=FALSE)
 
 first.data.col <- min(grep('^chip\\.', names(dat)), grep('^flag\\.', names(dat)))
 data.info <- dat[,1:(first.data.col-1)]
@@ -22,14 +22,14 @@ calls <- as.matrix(dat[,grep('^flag\\.', colnames(dat))])
 prob <- TRUE
 try({
   library(CGHtestpar)
-  pvs <-  pvalstest_logrank(calls, data.info, dataclinvar=phenodata, whtime=survival, whstatus=status, lgonly=as.integer(test.aberrations), niter=number.of.permutations, ncpus=4)
+  pvs <-  pvalstest_logrank(calls, data.info, dataclinvar=phenodata, whtime=which(colnames(phenodata) == survival), whstatus=which(colnames(phenodata) == status), lgonly=as.integer(test.aberrations), niter=number.of.permutations, ncpus=4)
   fdrs <- fdrperm(pvs)
   prob <- FALSE
 }, silent=TRUE)
 # if problems, fall back to sequential computing
 if (prob) {
   library(CGHtest)
-  pvs <-  pvalstest_logrank(calls, data.info, dataclinvar=phenodata, whtime=survival, whstatus=status, lgonly=as.integer(test.aberrations), niter=number.of.permutations)
+  pvs <-  pvalstest_logrank(calls, data.info, dataclinvar=phenodata, whtime=which(colnames(phenodata) == survival), whstatus=which(colnames(phenodata) == status), lgonly=as.integer(test.aberrations), niter=number.of.permutations)
   fdrs <- fdrperm(pvs)
 }
 


### PR DESCRIPTION
Fixes a bug in six copy number tools related to phenodata column names that contain spaces.

The bug probably affects all tools that have a METACOLUMN_SEL parameter. The fix is to include check.names=FALSE in the read.table command for the phenodata file.
