### PR TITLE
chipster server side data

### DIFF
--- a/src/main/applications/wrapper/fileserver/conf/chipster-config.xml
+++ b/src/main/applications/wrapper/fileserver/conf/chipster-config.xml
@@ -35,6 +35,11 @@
 	</configuration-module>
 
 	<configuration-module moduleId="filebroker">
+
+		<!-- This user is allowed to use the save-as-user parameter of the command line client -->
+		<entry entryKey="save-as-user" type="string">
+			<value>your-special-user-name-here</value>
+		</entry>
 	
 	    <!-- url of this file broker instance -->
 		<entry entryKey="url">

--- a/src/main/java/fi/csc/microarray/analyser/r/RAnalysisJob.java
+++ b/src/main/java/fi/csc/microarray/analyser/r/RAnalysisJob.java
@@ -241,7 +241,11 @@ public class RAnalysisJob extends OnDiskAnalysisJobBase {
 			inputReaders.add(new BufferedReader(new StringReader(rSnippet)));
 			i++;
 		}
-
+		//making frontend username available to the script
+		String value = this.getInputMessage().getUsername();
+		String rSnippet = transformVariable("chipster.R.job.calling.user",value, false);
+		logger.debug("added parameter (" +  rSnippet + ")");
+		inputReaders.add(new BufferedReader(new StringReader(rSnippet)));
 		
 		// load input script
 		String script = (String)analysis.getImplementation();

--- a/src/main/java/fi/csc/microarray/client/cli/CliClient.java
+++ b/src/main/java/fi/csc/microarray/client/cli/CliClient.java
@@ -96,6 +96,8 @@ public class CliClient {
 	private static final String OPT_WORKING_COPY = "working-copy";
 	private static final String OPT_LOCAL = "local";
 	private static final String OPT_CLOUD = "cloud";
+
+	private static final String OPT_SAVE_AS_USER = "save-as-user";
 	
 	private static final String CMD_INTERACTIVE = "interactive";
 	private static final String CMD_EXIT = "exit";
@@ -131,6 +133,8 @@ public class CliClient {
 	private static final String CMD_CLEAR_SESSION = "clear-session";
 		
 	private static final String DEFAULT_WORKING_COPY = "cli-working-copy.zip";
+
+	private static final String DEFAULT_SAVE_AS_USER = "";
 	
 	// without headless mode OSX will show this process in the dock and grab the focus
     static {
@@ -198,6 +202,8 @@ public class CliClient {
         addStringOption(parser, "-u", OPT_USERNAME, "chipster username");
         addStringOption(parser, "-p", OPT_PASSWORD, "chipster password");
         addStringOption(parser, "-W", OPT_WORKING_COPY, "name of the working copy session, either zip or cloud session").setDefault(DEFAULT_WORKING_COPY);        
+
+        addStringOption(parser, "-s", OPT_SAVE_AS_USER, "save cloud session as this user. Logged in user must have save-as-user rights.").setDefault(DEFAULT_SAVE_AS_USER);        
         
         addBooleanOption(parser, "-v", OPT_VERBOSE, "more verbose output");
         addBooleanOption(parser, "-q", OPT_QUIET, "uppress status messages and print only requested data");
@@ -376,7 +382,7 @@ public class CliClient {
 			listSessions(yaml);
 			
 		} else if (isCommand(CMD_DELETE_SESSION)) {
-			deleteSession(nameSpace.getString(ARG_DATASET));			
+			deleteSession(nameSpace.getString(ARG_SESSION));			
 			
 		} else if (isCommand(CMD_PRINT)) {
 			String dataset = nameSpace.getString(ARG_DATASET);
@@ -531,7 +537,8 @@ public class CliClient {
 			app.getSessionManager().saveSessionAndWait(false, new File(workingCopy), null);
 		} else {
 			checkCloudConfiguration();
-			app.getSessionManager().saveSessionAndWait(true, null, workingCopy);
+			String saveAsUser = nameSpace.getString(OPT_SAVE_AS_USER);
+			app.getSessionManager().saveSessionAndWait(true, null, workingCopy, saveAsUser);
 		}
 	}
 
@@ -1099,7 +1106,7 @@ public class CliClient {
 		List<DbSession> sessions = app.getSessionManager().listRemoteSessions();
 		
 		for (DbSession session : sessions) {
-			if (sessionName.equals(session.getName())) {
+			if ( sessionName.equals(session.getName())) {
 				return session.getDataId();
 			}
 		}

--- a/src/main/java/fi/csc/microarray/client/session/SessionManager.java
+++ b/src/main/java/fi/csc/microarray/client/session/SessionManager.java
@@ -230,7 +230,11 @@ public class SessionManager {
 		return buffer.toString();
 	}
 
-	public String saveStorageSession(String name) throws Exception {
+	public String saveStorageSession(String name ) throws Exception {
+		return saveStorageSession( name, "" );
+	}
+
+	public String saveStorageSession(String name, String saveAsUser ) throws Exception {
 						
 		String sessionId = CryptoKey.generateRandom();
 		SessionSaver sessionSaver = new SessionSaver(sessionId, dataManager);
@@ -239,12 +243,10 @@ public class SessionManager {
 		LinkedList<String> dataIds = sessionSaver.saveStorageSession();
 		
 		// add metadata to file broker database (make session visible)
-		fileBrokerClient.saveRemoteSession(name, sessionId, dataIds);
+		fileBrokerClient.saveRemoteSession(name, sessionId, dataIds, saveAsUser );
 		
 		return sessionId;
 	}
-
-	
 	
 	
 	/**
@@ -406,12 +408,16 @@ public class SessionManager {
 	}
 
 	public boolean saveSessionAndWait(boolean isRemote, File localFile, String remoteSessionName) {
+		return saveSessionAndWait( isRemote, localFile, remoteSessionName, "" );
+	}
+
+	public boolean saveSessionAndWait(boolean isRemote, File localFile, String remoteSessionName, String saveAsUser) {
 		
 		try {
 			String sessionId = null;
 			
 			if (isRemote) {
-				sessionId = saveStorageSession(remoteSessionName);				
+				sessionId = saveStorageSession(remoteSessionName,saveAsUser);				
 			} else {
 				saveSession(localFile);
 			}

--- a/src/main/java/fi/csc/microarray/filebroker/ChecksumInputStream.java
+++ b/src/main/java/fi/csc/microarray/filebroker/ChecksumInputStream.java
@@ -142,14 +142,14 @@ public class ChecksumInputStream extends DigestInputStream {
 	/**
 	 * Verify that checksums in both ends of network transmission are equal.
 	 * 
-	 * @return locally calculated checksum or null id calculation is disabled
+	 * @return locally calculated checksum or null if calculation is disabled
 	 * @throws ChecksumException
 	 */
-	public String verifyChecksums() throws ChecksumException {
+	public String verifyChecksums() throws ChecksumException, ContentLengthException {
 		
 		if (useChecksums) {
 			String localChecksum = getChecksum();
-			Md5FileUtils.verify(getRemoteChecksum(), localChecksum);
+			Md5FileUtils.verify(getRemoteChecksum(), localChecksum, null, null, null, null );
 			return localChecksum;
 		}
 		return null;
@@ -163,8 +163,9 @@ public class ChecksumInputStream extends DigestInputStream {
 	 * @throws ContentLengthException 
 	 */
 	public void verifyContentLength(Long contentLength) throws ChecksumException, ContentLengthException {				
-		
-		Md5FileUtils.verify(bytes, contentLength);
+		String localChecksum = getChecksum();
+		String remoteChecksum = getRemoteChecksum();
+		Md5FileUtils.verify(localChecksum,remoteChecksum, null, bytes, contentLength, null );
 	}
 
 	/**

--- a/src/main/java/fi/csc/microarray/filebroker/FileBrokerClient.java
+++ b/src/main/java/fi/csc/microarray/filebroker/FileBrokerClient.java
@@ -90,7 +90,7 @@ public interface FileBrokerClient {
 	 * @throws JMSException 
 	 * @throws ChecksumException 
 	 */
-	public abstract void getFile(String dataId, File destFile) throws IOException, JMSException, ChecksumException;	
+	public abstract void getFile(String dataId, File destFile) throws IOException, JMSException, ChecksumException, ContentLengthException;	
 
 	/**
 	 * Retrieves the list of public files or folders from the file broker. Method blocks until result is
@@ -109,7 +109,7 @@ public interface FileBrokerClient {
 	 * @param dataIds dataIds of other files in session
 	 * @throws JMSException
 	 */
-	public abstract void saveRemoteSession(String name, String sessionId, LinkedList<String> dataIds) throws JMSException;
+	public abstract void saveRemoteSession(String name, String sessionId, LinkedList<String> dataIds, String saveAsUser) throws JMSException;
 	
 	/**
 	 * Returns storage sessions (remote sessions) available at server. Returned array contains human readable names and corresponding URL's.

--- a/src/main/java/fi/csc/microarray/filebroker/Md5FileUtils.java
+++ b/src/main/java/fi/csc/microarray/filebroker/Md5FileUtils.java
@@ -113,6 +113,36 @@ public class Md5FileUtils {
 			return md5Stream.getChecksum();
 		}
 	}
+
+	/**
+	 * Compare two checksums and throw ChecksumException if both checksums aren't equal.
+	 * Null values are always accepted.
+	 * 
+	 * @param checksum1
+	 * @param checksum2
+	 */
+	public static void verify(
+		String checksum1,
+		String checksum2,
+		String checksum3,
+		Long long1,
+		Long long2,
+		Long long3
+		) throws ChecksumException, ContentLengthException
+	{
+		if( checksum1 != null && checksum1.equals("MAGIC_DO_NOT_CHECK_THIS_FILE_MD5") ) {
+			return;
+		}
+		if( checksum2 != null && checksum2.equals("MAGIC_DO_NOT_CHECK_THIS_FILE_MD5") ) {
+			return;
+		}
+		if( checksum3 != null && checksum3.equals("MAGIC_DO_NOT_CHECK_THIS_FILE_MD5") ) {
+			return;
+		}
+		verify(checksum1,checksum2,checksum3);
+		verify(long1,long2,long3);
+		return;
+	}
 	
 	/**
 	 * Compare two checksums and throw ChecksumException if both checksums aren't equal.

--- a/src/main/java/fi/csc/microarray/filebroker/SimpleFileBrokerClient.java
+++ b/src/main/java/fi/csc/microarray/filebroker/SimpleFileBrokerClient.java
@@ -90,7 +90,7 @@ public class SimpleFileBrokerClient implements FileBrokerClient {
 	}
 
 	@Override
-	public void saveRemoteSession(String name, String dataId, LinkedList<String> dataIds)
+	public void saveRemoteSession(String name, String dataId, LinkedList<String> dataIds, String saveAsUser)
 			throws JMSException {
 		throw new UnsupportedOperationException();
 	}

--- a/src/main/java/fi/csc/microarray/messaging/message/ParameterMessage.java
+++ b/src/main/java/fi/csc/microarray/messaging/message/ParameterMessage.java
@@ -57,6 +57,7 @@ public abstract class ParameterMessage extends ChipsterMessage {
 	public static final String PARAMETER_DATE_LIST = "date-list";
 	public static final String PARAMETER_STATUS_REPORT = "status-report";
 	public static final String PARAMETER_HOST = "host";
+	public static final String PARAMETER_SAVE_AS_USER = "save-as-user";
 	
 	private List<String> parameters = new LinkedList<String>();
 	private HashMap<String, String> namedParameters = new HashMap<String, String>();

--- a/src/main/java/fi/csc/microarray/util/UrlTransferUtil.java
+++ b/src/main/java/fi/csc/microarray/util/UrlTransferUtil.java
@@ -18,6 +18,7 @@ import java.util.zip.DeflaterOutputStream;
 import javax.jms.JMSException;
 
 import fi.csc.microarray.filebroker.ChecksumException;
+import fi.csc.microarray.filebroker.ContentLengthException;
 import fi.csc.microarray.filebroker.ChecksumInputStream;
 
 public class UrlTransferUtil {
@@ -54,7 +55,7 @@ public class UrlTransferUtil {
 	 * @throws IOException
 	 * @throws ChecksumException 
 	 */
-    public static String uploadStream(URL url, InputStream fis, boolean useChunked, boolean compress, boolean useChecksums, IOUtils.CopyProgressListener progressListener) throws IOException, ChecksumException {
+    public static String uploadStream(URL url, InputStream fis, boolean useChunked, boolean compress, boolean useChecksums, IOUtils.CopyProgressListener progressListener) throws IOException, ChecksumException, ContentLengthException {
 
     	HttpURLConnection connection = null;
     	String checksum = null;

--- a/src/main/modules/misc/R/create_cloud_project.R
+++ b/src/main/modules/misc/R/create_cloud_project.R
@@ -1,0 +1,32 @@
+# TOOL create_cloud_project.R: "Create new cloud session." (Create new cloud session from server side fastq and bam files. An error box will pop up when this tool has finished. Open the Details and read the first line for further information.)
+# PARAMETER project.name: "The project name" TYPE STRING (Enter a name for the new cloud project)
+# PARAMETER OPTIONAL file.filter: "A filter string" TYPE STRING (only files containing this string are imported: *file.filter*)
+# PARAMETER OPTIONAL file.extension: "The file extension" TYPE STRING (only files ending with file.extension are imported : *file.extension)
+
+# OH 29.04.2015
+
+user<-chipster.R.job.calling.user
+project<-project.name
+filter<-file.filter
+extension<-file.extension
+
+filter<-paste("filter=",filter,sep<-"",collapse<-"")
+filter<-gsub("\\s+","",filter)
+extension<-paste("extension=",extension,sep<-"",collapse<-"")
+extension<-gsub("\\s+","",extension)
+
+binary<-file.path(chipster.module.path ,"/shell/create_cloud_project.sh")
+binary.full<-paste(binary,user,project,filter,extension," > create_cloud_project.log 2>&1",sep<-" ")
+
+if( nchar(user) <= 0 || nchar(project) <= 0 || system(binary.full) != 0 ) {
+	out<-"The cloud project can not be created\r\n\r\n"
+} else {
+	out<-"The cloud project has been successful created. You can open it using File -> Open cloud session...\r\n\r\n"
+}
+
+log<-paste(readLines("create_cloud_project.log"),sep="",collapse="\r\n")
+
+out<-paste(out,"log file:\r\n\r\n",log,sep="")
+
+stop(out)
+

--- a/src/main/modules/misc/misc-module.xml
+++ b/src/main/modules/misc/misc-module.xml
@@ -90,6 +90,7 @@
 	    <tool runtime="R-3.0" module="common"><resource>select_columns.R</resource></tool> 
 	    <tool runtime="R-3.0" module="common"><resource>sort_and_select_columns.R</resource></tool>
 	    <tool runtime="R-3.0"><resource>concatenate.R</resource></tool>
+	    <tool runtime="R-3.0"><resource>create_cloud_project.R</resource></tool>
 	</category>
 	
 

--- a/src/main/modules/misc/shell/chipster-cli.bash
+++ b/src/main/modules/misc/shell/chipster-cli.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+host="http://127.0.0.1:8081"
+lib="chipster-current.jar"
+conf="chipster-config.xml"
+lib_url=$host/lib/$lib
+conf_url=$host/$conf
+
+# udpate jar
+curl --noproxy 127.0.0.1 --silent --show-error --remote-name --time-cond $lib $lib_url
+
+# if there are parameters
+if (($#))
+then
+	# set config path
+	param="--config $conf_url"
+else
+	param="-h"
+fi
+
+
+# command for running java
+cmd="java -Xmx900M -cp $lib fi.csc.microarray.client.cli.CliClient"
+
+# run
+$cmd $param "$@"
+

--- a/src/main/modules/misc/shell/create_cloud_project.sh
+++ b/src/main/modules/misc/shell/create_cloud_project.sh
@@ -1,0 +1,125 @@
+#!/bin/bash 
+# A script to create a new cloud project for the calling user
+# This script is called by ../R/create_cloud_project.R
+# OH 29.04.2015
+
+#
+# EDIT PARAMETERS SPECIFIC FOR LOCAL SERVICE:
+#
+
+#source directory to look for files to import into new cloud project
+source="/PATH/TO/THE/USERS/DATA"
+
+#chipster command line client credentials. This user needs to have save-as-user rights.
+chipster_save_as_user="your-special-user-name-here"
+chipster_save_as_user_password="XXXXXXXX"
+
+#
+# END OF SPECIFIC PARAMETERS
+#
+
+path=`dirname $0`
+chipstercli="${path}/chipster-cli.bash"
+
+user=$1
+name=$2
+
+filter=""
+if [ "$3" != "" ]
+then
+	filter=`echo "$3" | /bin/sed 's/^filter=//'`
+fi
+extension=""
+if [ "$4" != "" ]
+then
+	extension=`echo "$4" | /bin/sed 's/^extension=//'`
+fi
+
+if [ -f current_time.tmp ]
+then
+	rm current_time.tmp
+fi
+date "+%Y%m%d%H%M%S" > current_time.tmp
+echo $$ >> current_time.tmp
+id=`md5sum current_time.tmp | gawk '{print $1}'`
+
+echo -n "running in "`pwd`$'\r'$'\n'
+echo -n "running id is $id"$'\r'$'\n'
+echo -n "creating cloud project <$name> for user <$user>"$'\r'$'\n'
+
+
+if [ ! -d $source ]
+then
+	echo -n "ERROR: source directory does not exist"$'\r'$'\n'
+	exit 1
+fi
+
+count=`find $source -maxdepth 1 -name "*${filter}*${extension}" | wc -l | gawk '{print $1}'`
+if [ "$count" == "0" ]
+then
+	echo -n "ERROR: no files matching "'<*'"${filter}"'*'"${extension}"'>'" found in source directory"$'\r'$'\n'
+	exit 1
+fi
+
+$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose clear-session > /dev/null 2>&1
+
+#for type in fastq bam
+#do
+	count=`find $source -maxdepth 1 -name "*${filter}*${extension}" | wc -l | gawk '{print $1}'`
+	if [ "$count" != "0" ]
+	then
+		for file in $source/*${filter}*${extension}
+		do
+			base=`basename $file`
+			if [ ! -f $base ]
+			then
+				echo -n "$file $id"$'\r'$'\n' > $base
+				$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose import $base > /dev/null 2>&1
+				echo -n "imported $base"$'\r'$'\n'
+			else
+				echo -n "WARNING: $base already exists, $file not imported"$'\r'$'\n'
+			fi
+		done
+	fi
+#done
+
+$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose save-session --cloud $name > /dev/null 2>&1
+$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose clear-session > /dev/null 2>&1
+
+#for type in fastq bam
+#do
+	count=`find $source -maxdepth 1 -name "*${filter}*${extension}" | wc -l | gawk '{print $1}'`
+	if [ "$count" != "0" ]
+	then
+		for file in $source/*${filter}*${extension}
+		do
+			base=`basename $file`
+			count=`find /mnt/data/storage/ -type f -newer current_time.tmp -exec grep -l '^'"$file $id" {} \; | wc -l | gawk '{print $1}'`
+			if [ "$count" == "1" ]
+			then
+				target=`find /mnt/data/storage/ -type f -newer current_time.tmp -exec grep -l '^'"$file $id" {} \;`
+				target_base=`basename $target`
+				rm $target
+				ln -s $file $target
+				if [ -f $target.md5 ]
+				then
+					echo "MAGIC_DO_NOT_CHECK_THIS_FILE_MD5  ${target_base}" > $target.md5
+				fi
+			else
+				echo -n "ERROR: $file in more than one file or not found at all"$'\r'$'\n'
+				$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose delete-session --cloud $name > /dev/null 2>&1
+				exit 1
+			fi
+		done
+	fi
+#done
+
+$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose open-session --cloud $name > /dev/null 2>&1
+$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose --save-as-user "$user" save-session --cloud $name > /dev/null 2>&1
+$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose delete-session --cloud $name > /dev/null 2>&1
+$chipstercli -u "$chipster_save_as_user" -p "$chipster_save_as_user_password" --verbose clear-session > /dev/null 2>&1
+
+echo -n "ready."$'\r'$'\n'$'\r'$'\n'
+
+exit 0 
+

--- a/src/main/resources/build.number
+++ b/src/main/resources/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Wed Jan 14 14:31:32 EET 2015
-build.number=1436
+#Wed Apr 29 17:47:54 CEST 2015
+build.number=1481

--- a/src/main/resources/chipster-config-specification.xml
+++ b/src/main/resources/chipster-config-specification.xml
@@ -89,6 +89,9 @@
 	
 	
 	<configuration-module moduleId="filebroker" description="file broker">
+		<entry entryKey="save-as-user" type="string" description="A user name who is allowed to save cloud session as another user name from the command line client">
+			<value></value>
+		</entry>
 	
 		<entry entryKey="file-root-path" type="string" description="path to file broker root directory">
 			<value>file-root</value>

--- a/src/main/resources/version.number
+++ b/src/main/resources/version.number
@@ -1,2 +1,2 @@
-#Wed, 14 Jan 2015 14:31:32 +0200
-version.number=3.1.2
+#Wed, 29 Apr 2015 17:47:54 +0200
+version.number=3.2.0

--- a/src/test/java/fi/csc/microarray/filebroker/ChecksumInputStreamTest.java
+++ b/src/test/java/fi/csc/microarray/filebroker/ChecksumInputStreamTest.java
@@ -25,7 +25,7 @@ public class ChecksumInputStreamTest {
 	};
 	
 	@Test
-	public void test() throws IOException, ChecksumException {
+	public void test() throws IOException, ChecksumException, ContentLengthException {
 		
 		for (String[] example : examples) {
 			// example md5 is calculated from bytes, not from hex String, 
@@ -58,7 +58,7 @@ public class ChecksumInputStreamTest {
 		return md5;
 	}
 	
-	private String testVerification(byte[] data, String exampleMd5) throws IOException, ChecksumException {
+	private String testVerification(byte[] data, String exampleMd5) throws IOException, ChecksumException, ContentLengthException {
 		
 		ChecksumInputStream stream = preprocess(data, new TestURLConnection(exampleMd5));		
 		String md5 =  stream.verifyChecksums();		


### PR DESCRIPTION
Hi Petri,

I failed with my first approach, but found another (maybe better)
solution for the problem. For everybody, here is the description of
the problem and the proposed solution:

Problem:
Using chipster for NGS data can be problematic with large datasets.
Our smaller projects may have several fastq files with each
file a size of 15-20 Gbyte, there are much larger projects. Creating
chipster session with files like that is not feasible as copying and
transporting the data over network just takes to long. Using
cloud project does not resolve this problem as data is copied
from the users source into the chipster file repository, still it takes
to long. Creating the md5 checksum of files of this size adds to
the processing time.

Solution:
The proposed solution to this problem is, allowing the user to use
cloud projects. The creation is triggered by the user from the clients
GUI and the cloud project is created at the back-end automatically
without any copying of files and without md5 checksum calculation.
The data import into chipster at the back-end can be done using the
chipster-command-line-client (CLI). Two new tools
comp/modules/misc/R/create_cloud_project.R
and
comp/modules/misc/shell/create_cloud_project.sh
have been developed. The first is called from the GUI and calls the
second. They manage the creation of the cloud project.
The user does not need to provide his user name and password as
parameters to the tools. Therefore chipster source has been changed
to provide the tool with the calling user name. The CLI runs as a
different user, which has the special configurable privilege to be able
to save the cloud session as another user, in this case to save as the calling
user from the GUI (overwriting existing sessions is not possible).
With the known GUI user name the tool can also make sure, that only
files belonging to this user can be imported into a new session. This has
to be done on base of the underlying system and by changing the
two new tools accordingly.
Files are imported into the sessions using small dummy files. These dummy
files are than identified in the chipster file repository and exchanged by
symbolic links to the real files. As md5 checksum a magic word
"MAGIC_DO_NOT_CHECK_THIS_FILE_MD5" is inserted which stops the
chipster system to perform md5 and filesize checks.
